### PR TITLE
Add interfaces for models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 **/__pycache__
 .vscode
-.env
+*.env
 node_modules
 unused-commands
 d.py/

--- a/commands/owner/createRoles.ts
+++ b/commands/owner/createRoles.ts
@@ -20,10 +20,13 @@ export default {
     console.log(
       chalk.red("------------------------------------------------------")
     );
+    if (interaction.guild === null) {
+      return;
+    }
     // Create the roles
-    await createRoles(interaction.guild!, classModel);
-    await createRoles(interaction.guild!, staffModel);
-    await createRoles(interaction.guild!, yearModel);
+    await createRoles(interaction.guild, classModel);
+    await createRoles(interaction.guild, staffModel);
+    await createRoles(interaction.guild, yearModel);
     interaction.reply({
       content: "Roles created!",
       ephemeral: true,

--- a/commands/owner/createRoles.ts
+++ b/commands/owner/createRoles.ts
@@ -13,11 +13,7 @@ export default {
   ownerOnly: true,
 
   callback: async ({ interaction }) => {
-    console.log(
-      chalk.green(
-        "Creating roles...\nCopy and paste the following output into your .env file"
-      )
-    );
+    console.log(chalk.green("Creating roles..."));
     console.log(
       chalk.red("------------------------------------------------------")
     );

--- a/commands/owner/createRoles.ts
+++ b/commands/owner/createRoles.ts
@@ -1,6 +1,9 @@
 import { ICommand } from "wokcommands";
 import { createRoles } from "../../rolesOps";
 import chalk from "chalk";
+import { classModel } from "../../models/classModel";
+import { staffModel } from "../../models/staffModel";
+import { yearModel } from "../../models/yearModel";
 
 export default {
   name: "createRoles",
@@ -18,9 +21,9 @@ export default {
       chalk.red("------------------------------------------------------")
     );
     // Create the roles
-    createRoles(interaction.guild!, "class");
-    createRoles(interaction.guild!, "staff");
-    createRoles(interaction.guild!, "year");
+    createRoles(interaction.guild!, classModel);
+    createRoles(interaction.guild!, staffModel);
+    createRoles(interaction.guild!, yearModel);
     interaction.reply({
       content: "Roles created!",
       ephemeral: true,

--- a/commands/owner/createRoles.ts
+++ b/commands/owner/createRoles.ts
@@ -21,9 +21,9 @@ export default {
       chalk.red("------------------------------------------------------")
     );
     // Create the roles
-    createRoles(interaction.guild!, classModel);
-    createRoles(interaction.guild!, staffModel);
-    createRoles(interaction.guild!, yearModel);
+    await createRoles(interaction.guild!, classModel);
+    await createRoles(interaction.guild!, staffModel);
+    await createRoles(interaction.guild!, yearModel);
     interaction.reply({
       content: "Roles created!",
       ephemeral: true,

--- a/commands/owner/csClassPoll.ts
+++ b/commands/owner/csClassPoll.ts
@@ -27,8 +27,7 @@ export default {
       return;
     }
 
-    // let classes: IClass[] = await classModel.find({}).sort({ CODE: 1 });
-    let classes = await classModel.find({}).sort({ CODE: 1 });
+    const classes = await classModel.find({}).sort({ CODE: 1 });
     const class_chunks = split_list(classes, 25);
 
     let rows: MessageActionRow[] = [];

--- a/commands/owner/csClassPoll.ts
+++ b/commands/owner/csClassPoll.ts
@@ -6,17 +6,8 @@ import {
 } from "discord.js";
 import chalk from "chalk";
 import { ICommand } from "wokcommands";
-import classModel from "../../models/classModel";
+import { classModel, IClass } from "../../models/classModel";
 import { checkForRoles } from "../../rolesOps";
-
-export interface Class {
-  CODE: string;
-  TITLE: string;
-  INFO: string;
-  ROLE_NAME: string;
-  ROLE_ID: string;
-  UUID: string;
-}
 
 export default {
   name: "csClassPoll",
@@ -36,7 +27,8 @@ export default {
       return;
     }
 
-    let classes: Class[] = await classModel.find({}).sort({ CODE: 1 });
+    // let classes: IClass[] = await classModel.find({}).sort({ CODE: 1 });
+    let classes = await classModel.find({}).sort({ CODE: 1 });
     const class_chunks = split_list(classes, 25);
 
     let rows: MessageActionRow[] = [];
@@ -103,7 +95,7 @@ function split_list(list: Array<any>, max_list_len: number) {
 }
 
 // consumes a Class and returns Message Selec tOption data
-function create_option_from_class(_class: Class): MessageSelectOptionData {
+function create_option_from_class(_class: IClass): MessageSelectOptionData {
   return {
     label: _class.CODE,
     value: _class.CODE,

--- a/commands/user/clear.ts
+++ b/commands/user/clear.ts
@@ -1,6 +1,9 @@
 import chalk from "chalk";
 import { GuildMember } from "discord.js";
 import { ICommand } from "wokcommands";
+import { classModel } from "../../models/classModel";
+import { staffModel } from "../../models/staffModel";
+import { yearModel } from "../../models/yearModel";
 import { removeRole } from "../../rolesOps";
 
 export default {
@@ -16,9 +19,9 @@ export default {
     // Remove roles from user
     if (!interaction.member) return;
     const member = interaction.member as GuildMember;
-    removeRole(member, "class");
-    removeRole(member, "year");
-    removeRole(member, "staff");
+    removeRole(member, classModel);
+    removeRole(member, yearModel);
+    removeRole(member, staffModel);
     // Reply to the user
     interaction.reply({
       content: "Cleared all roles that I have assigned to you.",

--- a/commands/user/clear.ts
+++ b/commands/user/clear.ts
@@ -19,9 +19,9 @@ export default {
     // Remove roles from user
     if (!interaction.member) return;
     const member = interaction.member as GuildMember;
-    removeRole(member, classModel);
-    removeRole(member, yearModel);
-    removeRole(member, staffModel);
+    await removeRole(member, classModel);
+    await removeRole(member, yearModel);
+    await removeRole(member, staffModel);
     // Reply to the user
     interaction.reply({
       content: "Cleared all roles that I have assigned to you.",

--- a/features/interactionCreate.ts
+++ b/features/interactionCreate.ts
@@ -1,5 +1,7 @@
 import { Client, MessageEmbed, GuildMember } from "discord.js";
+import { yearModel } from "../models/yearModel";
 import { removeRole, addNewRole } from "../rolesOps";
+import { staffModel } from "../models/staffModel";
 
 // Listen interactionCreate events from the client
 export default (client: Client): void => {
@@ -30,11 +32,12 @@ export default (client: Client): void => {
         ephemeral: true,
       });
       // Remove any previous roles in the dictionary from the user
+      removeRole(member, yearModel);
+
+      // No role to add
       if (interaction.values[0] === "None") {
-        removeRole(member, "year");
         return;
       }
-      removeRole(member, "year");
 
       // Assign the new role to the user
       addNewRole(member, "year", interaction.values[0]);
@@ -52,12 +55,14 @@ export default (client: Client): void => {
         ],
         ephemeral: true,
       });
+
       // Remove any previous roles in the dictionary from the user
+      removeRole(member, staffModel);
+
+      // No role to add
       if (interaction.values[0] === "None") {
-        removeRole(member, "staff");
         return;
       }
-      removeRole(member, "staff");
 
       // Assign the new role to the user
       addNewRole(member, "staff", interaction.values[0]);

--- a/features/interactionCreate.ts
+++ b/features/interactionCreate.ts
@@ -2,6 +2,7 @@ import { Client, MessageEmbed, GuildMember } from "discord.js";
 import { yearModel } from "../models/yearModel";
 import { removeRole, addNewRole } from "../rolesOps";
 import { staffModel } from "../models/staffModel";
+import { classModel } from "../models/classModel";
 
 // Listen interactionCreate events from the client
 export default (client: Client): void => {
@@ -40,7 +41,7 @@ export default (client: Client): void => {
       }
 
       // Assign the new role to the user
-      addNewRole(member, "year", interaction.values[0]);
+      addNewRole(member, yearModel, interaction.values[0]);
     } else if (interaction.customId === "collegeStaffPoll") {
       // Set the embed title
       const title = "College Staff Poll";
@@ -65,7 +66,7 @@ export default (client: Client): void => {
       }
 
       // Assign the new role to the user
-      addNewRole(member, "staff", interaction.values[0]);
+      addNewRole(member, staffModel, interaction.values[0]);
     } else if (interaction.customId.startsWith("csClassPoll+")) {
       // Set the embed title
       const title = "CS Class Poll";
@@ -82,7 +83,7 @@ export default (client: Client): void => {
       });
       // Assign the new role to the user
 
-      addNewRole(member, "class", interaction.values[0]);
+      addNewRole(member, classModel, interaction.values[0]);
     }
   });
 };

--- a/features/interactionCreate.ts
+++ b/features/interactionCreate.ts
@@ -33,7 +33,7 @@ export default (client: Client): void => {
         ephemeral: true,
       });
       // Remove any previous roles in the dictionary from the user
-      removeRole(member, yearModel);
+      await removeRole(member, yearModel);
 
       // No role to add
       if (interaction.values[0] === "None") {
@@ -41,7 +41,7 @@ export default (client: Client): void => {
       }
 
       // Assign the new role to the user
-      addNewRole(member, yearModel, interaction.values[0]);
+      await addNewRole(member, yearModel, interaction.values[0]);
     } else if (interaction.customId === "collegeStaffPoll") {
       // Set the embed title
       const title = "College Staff Poll";
@@ -58,7 +58,7 @@ export default (client: Client): void => {
       });
 
       // Remove any previous roles in the dictionary from the user
-      removeRole(member, staffModel);
+      await removeRole(member, staffModel);
 
       // No role to add
       if (interaction.values[0] === "None") {
@@ -66,7 +66,7 @@ export default (client: Client): void => {
       }
 
       // Assign the new role to the user
-      addNewRole(member, staffModel, interaction.values[0]);
+      await addNewRole(member, staffModel, interaction.values[0]);
     } else if (interaction.customId.startsWith("csClassPoll+")) {
       // Set the embed title
       const title = "CS Class Poll";
@@ -83,7 +83,7 @@ export default (client: Client): void => {
       });
       // Assign the new role to the user
 
-      addNewRole(member, classModel, interaction.values[0]);
+      await addNewRole(member, classModel, interaction.values[0]);
     }
   });
 };

--- a/index.ts
+++ b/index.ts
@@ -61,9 +61,9 @@ client.on("ready", () => {
 
   // Set up the connection to the database
   wok.on("databaseConnected", async () => {
-    checkIfCollectionsExist(classModel);
-    checkIfCollectionsExist(staffModel);
-    checkIfCollectionsExist(yearModel);
+    await checkIfCollectionsExist(classModel);
+    await checkIfCollectionsExist(staffModel);
+    await checkIfCollectionsExist(yearModel);
     console.log(chalk.green("Connected to the database"));
   });
 });

--- a/index.ts
+++ b/index.ts
@@ -6,7 +6,10 @@ import chalk from "chalk";
 import dotenv from "dotenv";
 
 // import custom modules
-import { checkForRoles } from "./rolesOps";
+import { checkForRoles, checkIfCollectionsExist } from "./rolesOps";
+import { classModel } from "./models/classModel";
+import { staffModel } from "./models/staffModel";
+import { yearModel } from "./models/yearModel";
 
 // import all environment variables from .env file
 dotenv.config();
@@ -58,6 +61,9 @@ client.on("ready", () => {
 
   // Set up the connection to the database
   wok.on("databaseConnected", async () => {
+    checkIfCollectionsExist(classModel);
+    checkIfCollectionsExist(staffModel);
+    checkIfCollectionsExist(yearModel);
     console.log(chalk.green("Connected to the database"));
   });
 });

--- a/models/classModel.ts
+++ b/models/classModel.ts
@@ -13,14 +13,14 @@ export interface IClass {
 }
 
 const ClassSchema = new Schema({
-  id: { type: String, required: true },
+  id: { type: String },
   CODE: { type: String, required: true },
   TITLE: { type: String, required: true },
   INFO: { type: String, required: true },
   ROLE_NAME: { type: String, required: true },
   ROLE_ID: { type: String, required: true },
-  CHANNEL_NAME: { type: String, required: true },
-  CHANNEL_ID: { type: String, required: true },
+  CHANNEL_NAME: { type: String },
+  CHANNEL_ID: { type: String },
   UUID: { type: String, default: "remove" },
 });
 

--- a/models/classModel.ts
+++ b/models/classModel.ts
@@ -1,12 +1,11 @@
 import mongoose, { Schema } from "mongoose";
+import { IRole } from "../rolesOps";
 
-export interface IClass {
+export interface IClass extends IRole {
   id: string;
   CODE: string;
   TITLE: string;
   INFO: string;
-  ROLE_NAME: string;
-  ROLE_ID: string;
   CHANNEL_NAME: string;
   CHANNEL_ID: string;
   UUID: string;

--- a/models/classModel.ts
+++ b/models/classModel.ts
@@ -24,4 +24,6 @@ const ClassSchema = new Schema({
   UUID: { type: String, default: "remove" },
 });
 
-export let classModel = mongoose.model<IClass>("class", ClassSchema);
+const name = "class";
+
+export const classModel = mongoose.model<IClass>(name, ClassSchema, name);

--- a/models/classModel.ts
+++ b/models/classModel.ts
@@ -1,6 +1,18 @@
 import mongoose, { Schema } from "mongoose";
 
-const CLASS = new Schema({
+export interface IClass {
+  id: string;
+  CODE: string;
+  TITLE: string;
+  INFO: string;
+  ROLE_NAME: string;
+  ROLE_ID: string;
+  CHANNEL_NAME: string;
+  CHANNEL_ID: string;
+  UUID: string;
+}
+
+const ClassSchema = new Schema({
   id: String,
   CODE: String,
   TITLE: String,
@@ -12,6 +24,4 @@ const CLASS = new Schema({
   UUID: String,
 });
 
-const name = "class";
-
-export = mongoose.models[name] || mongoose.model(name, CLASS, name);
+export let classModel = mongoose.model<IClass>("class", ClassSchema);

--- a/models/classModel.ts
+++ b/models/classModel.ts
@@ -13,15 +13,15 @@ export interface IClass {
 }
 
 const ClassSchema = new Schema({
-  id: String,
-  CODE: String,
-  TITLE: String,
-  INFO: String,
-  ROLE_NAME: String,
-  ROLE_ID: String,
-  CHANNEL_NAME: String,
-  CHANNEL_ID: String,
-  UUID: String,
+  id: { type: String, required: true },
+  CODE: { type: String, required: true },
+  TITLE: { type: String, required: true },
+  INFO: { type: String, required: true },
+  ROLE_NAME: { type: String, required: true },
+  ROLE_ID: { type: String, required: true },
+  CHANNEL_NAME: { type: String, required: true },
+  CHANNEL_ID: { type: String, required: true },
+  UUID: { type: String, default: "remove" },
 });
 
 export let classModel = mongoose.model<IClass>("class", ClassSchema);

--- a/models/staffModel.ts
+++ b/models/staffModel.ts
@@ -1,4 +1,4 @@
-import mongoose, { Schema, model } from "mongoose";
+import mongoose, { Schema } from "mongoose";
 
 export interface IStaff {
   id: string;

--- a/models/staffModel.ts
+++ b/models/staffModel.ts
@@ -1,10 +1,9 @@
 import mongoose, { Schema } from "mongoose";
+import { IRole } from "../rolesOps";
 
-export interface IStaff {
+export interface IStaff extends IRole {
   id: string;
   NAME: string;
-  ROLE_NAME: string;
-  ROLE_ID: string;
 }
 
 const StaffSchema = new Schema({

--- a/models/staffModel.ts
+++ b/models/staffModel.ts
@@ -14,4 +14,7 @@ const StaffSchema = new Schema({
   ROLE_ID: { type: String, required: true },
 });
 
-export let staffModel = model("staff", StaffSchema);
+// export let staffModel = model("staff", StaffSchema);
+const name = "staff";
+
+export const staffModel = mongoose.model<IStaff>(name, StaffSchema, name);

--- a/models/staffModel.ts
+++ b/models/staffModel.ts
@@ -8,7 +8,7 @@ export interface IStaff {
 }
 
 const StaffSchema = new Schema({
-  id: { type: String, required: true },
+  id: { type: String },
   NAME: { type: String, required: true },
   ROLE_NAME: { type: String, required: true },
   ROLE_ID: { type: String, required: true },

--- a/models/staffModel.ts
+++ b/models/staffModel.ts
@@ -1,4 +1,4 @@
-import mongoose, { Schema } from "mongoose";
+import mongoose, { Schema, model } from "mongoose";
 
 export interface IStaff {
   id: string;
@@ -8,10 +8,10 @@ export interface IStaff {
 }
 
 const StaffSchema = new Schema({
-  id: String,
-  NAME: String,
-  ROLE_NAME: String,
-  ROLE_ID: String,
+  id: { type: String, required: true },
+  NAME: { type: String, required: true },
+  ROLE_NAME: { type: String, required: true },
+  ROLE_ID: { type: String, required: true },
 });
 
-export let staffModel = mongoose.model("staff", StaffSchema);
+export let staffModel = model("staff", StaffSchema);

--- a/models/staffModel.ts
+++ b/models/staffModel.ts
@@ -14,7 +14,6 @@ const StaffSchema = new Schema({
   ROLE_ID: { type: String, required: true },
 });
 
-// export let staffModel = model("staff", StaffSchema);
 const name = "staff";
 
 export const staffModel = mongoose.model<IStaff>(name, StaffSchema, name);

--- a/models/staffModel.ts
+++ b/models/staffModel.ts
@@ -1,12 +1,17 @@
 import mongoose, { Schema } from "mongoose";
 
-const STAFF = new Schema({
+export interface IStaff {
+  id: string;
+  NAME: string;
+  ROLE_NAME: string;
+  ROLE_ID: string;
+}
+
+const StaffSchema = new Schema({
   id: String,
   NAME: String,
   ROLE_NAME: String,
   ROLE_ID: String,
 });
 
-const name = "staff";
-
-export = mongoose.models[name] || mongoose.model(name, STAFF, name);
+export let staffModel = mongoose.model("staff", StaffSchema);

--- a/models/yearModel.ts
+++ b/models/yearModel.ts
@@ -8,10 +8,10 @@ export interface IYear {
 }
 
 const YearSchema = new Schema({
-  id: String,
-  NAME: String,
-  ROLE_NAME: String,
-  ROLE_ID: String,
+  id: { type: String, required: true },
+  NAME: { type: String, required: true },
+  ROLE_NAME: { type: String, required: true },
+  ROLE_ID: { type: String, required: true },
 });
 
 export let yearModel = mongoose.model("year", YearSchema);

--- a/models/yearModel.ts
+++ b/models/yearModel.ts
@@ -8,7 +8,7 @@ export interface IYear {
 }
 
 const YearSchema = new Schema({
-  id: { type: String, required: true },
+  id: { type: String },
   NAME: { type: String, required: true },
   ROLE_NAME: { type: String, required: true },
   ROLE_ID: { type: String, required: true },

--- a/models/yearModel.ts
+++ b/models/yearModel.ts
@@ -1,12 +1,17 @@
 import mongoose, { Schema } from "mongoose";
 
-const YEAR = new Schema({
+export interface IYear {
+  id: string;
+  NAME: string;
+  ROLE_NAME: string;
+  ROLE_ID: string;
+}
+
+const YearSchema = new Schema({
   id: String,
   NAME: String,
   ROLE_NAME: String,
   ROLE_ID: String,
 });
 
-const name = "year";
-
-export = mongoose.models[name] || mongoose.model(name, YEAR, name);
+export let yearModel = mongoose.model("year", YearSchema);

--- a/models/yearModel.ts
+++ b/models/yearModel.ts
@@ -1,10 +1,9 @@
 import mongoose, { Schema } from "mongoose";
+import { IRole } from "../rolesOps";
 
-export interface IYear {
+export interface IYear extends IRole {
   id: string;
   NAME: string;
-  ROLE_NAME: string;
-  ROLE_ID: string;
 }
 
 const YearSchema = new Schema({

--- a/models/yearModel.ts
+++ b/models/yearModel.ts
@@ -14,6 +14,5 @@ const YearSchema = new Schema({
   ROLE_ID: { type: String, required: true },
 });
 
-// export let yearModel = mongoose.model("year", YearSchema);
 const name = "year";
 export let yearModel = mongoose.model<IYear>(name, YearSchema, name);

--- a/models/yearModel.ts
+++ b/models/yearModel.ts
@@ -15,4 +15,4 @@ const YearSchema = new Schema({
 });
 
 const name = "year";
-export let yearModel = mongoose.model<IYear>(name, YearSchema, name);
+export const yearModel = mongoose.model<IYear>(name, YearSchema, name);

--- a/models/yearModel.ts
+++ b/models/yearModel.ts
@@ -14,4 +14,6 @@ const YearSchema = new Schema({
   ROLE_ID: { type: String, required: true },
 });
 
-export let yearModel = mongoose.model("year", YearSchema);
+// export let yearModel = mongoose.model("year", YearSchema);
+const name = "year";
+export let yearModel = mongoose.model<IYear>(name, YearSchema, name);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "axios": "^0.27.2",
-        "chalk": "^5.0.1",
+        "chalk": "4.1.2",
         "discord.js": "^13.9.2",
         "mongoose": "^6.5.4",
         "path": "^0.12.7",
@@ -96,9 +96,9 @@
       }
     },
     "node_modules/@sapphire/shapeshift": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.5.1.tgz",
-      "integrity": "sha512-7JFsW5IglyOIUQI1eE0g6h06D/Far6HqpcowRScgCiLSqTf3hhkPWCWotVTtVycnDCMYIwPeaw6IEPBomKC8pA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.6.0.tgz",
+      "integrity": "sha512-tu2WLRdo5wotHRvsCkspg3qMiP6ETC3Q1dns1Q5V6zKUki+1itq6AbhMwohF9ZcLoYqg+Y8LkgRRtVxxTQVTBQ==",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "lodash.uniqwith": "^4.5.0"
@@ -129,9 +129,9 @@
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ=="
     },
     "node_modules/@types/node": {
-      "version": "18.7.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.13.tgz",
-      "integrity": "sha512-46yIhxSe5xEaJZXWdIBP7GU4HDTG8/eo0qd9atdiL+lFpA03y8KS+lkTN834TWJj5767GbWv4n/P6efyTFt1Dw=="
+      "version": "18.7.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.15.tgz",
+      "integrity": "sha512-XnjpaI8Bgc3eBag2Aw4t2Uj/49lLBSStHWfqKvIuXD7FIrZyMLWp8KuAFHAqxMZYTF9l08N1ctUn9YNybZJVmQ=="
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.2",
@@ -156,9 +156,9 @@
       }
     },
     "node_modules/@types/webidl-conversions": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-6.1.1.tgz",
-      "integrity": "sha512-XAahCdThVuCFDQLT7R7Pk/vqeObFNL3YqRyFZg+AqAP/W1/w3xHaIxuW7WszQqTbIBOPRcItYJIou3i/mppu3Q=="
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog=="
     },
     "node_modules/@types/whatwg-url": {
       "version": "8.2.2",
@@ -194,6 +194,20 @@
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/arg": {
@@ -269,15 +283,35 @@
       }
     },
     "node_modules/chalk": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
-      "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
       "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -408,6 +442,14 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ieee754": {
@@ -675,6 +717,17 @@
         "memory-pager": "^1.0.2"
       }
     },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/tr46": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
@@ -880,9 +933,9 @@
       "integrity": "sha512-JkLdIsP8fPAdh9ZZjrbHWR/+mZj0wvKS5ICibcLrRI1j84UmLMshx5n9QmL8b95d4onJ2xxiyugTgSAX7AalmA=="
     },
     "@sapphire/shapeshift": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.5.1.tgz",
-      "integrity": "sha512-7JFsW5IglyOIUQI1eE0g6h06D/Far6HqpcowRScgCiLSqTf3hhkPWCWotVTtVycnDCMYIwPeaw6IEPBomKC8pA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.6.0.tgz",
+      "integrity": "sha512-tu2WLRdo5wotHRvsCkspg3qMiP6ETC3Q1dns1Q5V6zKUki+1itq6AbhMwohF9ZcLoYqg+Y8LkgRRtVxxTQVTBQ==",
       "requires": {
         "fast-deep-equal": "^3.1.3",
         "lodash.uniqwith": "^4.5.0"
@@ -909,9 +962,9 @@
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ=="
     },
     "@types/node": {
-      "version": "18.7.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.13.tgz",
-      "integrity": "sha512-46yIhxSe5xEaJZXWdIBP7GU4HDTG8/eo0qd9atdiL+lFpA03y8KS+lkTN834TWJj5767GbWv4n/P6efyTFt1Dw=="
+      "version": "18.7.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.15.tgz",
+      "integrity": "sha512-XnjpaI8Bgc3eBag2Aw4t2Uj/49lLBSStHWfqKvIuXD7FIrZyMLWp8KuAFHAqxMZYTF9l08N1ctUn9YNybZJVmQ=="
     },
     "@types/node-fetch": {
       "version": "2.6.2",
@@ -935,9 +988,9 @@
       }
     },
     "@types/webidl-conversions": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-6.1.1.tgz",
-      "integrity": "sha512-XAahCdThVuCFDQLT7R7Pk/vqeObFNL3YqRyFZg+AqAP/W1/w3xHaIxuW7WszQqTbIBOPRcItYJIou3i/mppu3Q=="
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog=="
     },
     "@types/whatwg-url": {
       "version": "8.2.2",
@@ -965,6 +1018,14 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
+    },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
     },
     "arg": {
       "version": "4.1.3",
@@ -1008,9 +1069,26 @@
       }
     },
     "chalk": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
-      "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w=="
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -1100,6 +1178,11 @@
         "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
       }
+    },
+    "has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
     },
     "ieee754": {
       "version": "1.2.1",
@@ -1291,6 +1374,14 @@
       "optional": true,
       "requires": {
         "memory-pager": "^1.0.2"
+      }
+    },
+    "supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "requires": {
+        "has-flag": "^4.0.0"
       }
     },
     "tr46": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/Antares-Network/CSSC-Bot#readme",
   "dependencies": {
     "axios": "^0.27.2",
-    "chalk": "^5.0.1",
+    "chalk": "4.1.2",
     "discord.js": "^13.9.2",
     "mongoose": "^6.5.4",
     "path": "^0.12.7",

--- a/rolesOps.ts
+++ b/rolesOps.ts
@@ -56,23 +56,25 @@ export async function removeRole<T extends IRole>(
   }
 }
 
-export async function addNewRole(
+export async function addNewRole<T extends IRole>(
   member: GuildMember,
-  type: string,
+  model: Model<T>,
   id: string
 ) {
   // This function is triggered when a user changes their role, it adds the new role to the user
-  let role: IClass | IYear | IStaff | null = null;
-  if (type === "class") {
-    role = await classModel.findOne({ CODE: id });
-  } else if (type === "staff") {
-    role = await staffModel.findOne({ NAME: id });
-  } else if (type === "year") {
-    role = await yearModel.findOne({ NAME: id });
+  let role;
+  switch (model.constructor) {
+    case classModel:
+      //TODO: Rewrite IRole to include name, and replace CODE with name
+      role = await model.findOne({ CODE: id });
+    default:
+      role = await model.findOne({ Name: id });
   }
+
   if (role === null) {
     throw new Error(`No roll found with id: ${id}`);
   }
+
   if (!member.roles.cache.has(role.ROLE_ID)) {
     await member.roles.add(role.ROLE_ID);
     console.log(

--- a/rolesOps.ts
+++ b/rolesOps.ts
@@ -3,7 +3,13 @@ import chalk from "chalk";
 import { classModel, IClass } from "./models/classModel";
 import { staffModel, IStaff } from "./models/staffModel";
 import { yearModel, IYear } from "./models/yearModel";
+import { Model } from "mongoose";
 
+export async function checkIfCollectionsExist(model: Model<any>) {
+  if (!(await model.exists({}))) {
+    throw new Error(`${model.name} collection does not exist`);
+  }
+}
 async function dbQuery() {
   const classes = await classModel.find({});
   const staff = await staffModel.find({});

--- a/rolesOps.ts
+++ b/rolesOps.ts
@@ -5,6 +5,11 @@ import { staffModel, IStaff } from "./models/staffModel";
 import { yearModel, IYear } from "./models/yearModel";
 import { Model } from "mongoose";
 
+export interface IRole {
+  ROLE_NAME: string;
+  ROLE_ID: string;
+}
+
 export async function checkIfCollectionsExist(model: Model<any>) {
   if (!(await model.exists({}))) {
     throw new Error(`${model.name} collection does not exist`);

--- a/rolesOps.ts
+++ b/rolesOps.ts
@@ -10,7 +10,7 @@ export interface IRole {
   ROLE_ID: string;
 }
 
-export async function checkIfCollectionsExist(model: Model<any>) {
+export async function checkIfCollectionsExist<T>(model: Model<T>) {
   if (!(await model.exists({}))) {
     throw new Error(`${model.name} collection does not exist`);
   }

--- a/rolesOps.ts
+++ b/rolesOps.ts
@@ -85,15 +85,11 @@ export async function addNewRole(
   }
 }
 
-export async function createRoles(guild: Guild, type: string): Promise<void> {
-  let list = null;
-  if (type === "class") {
-    list = await classModel.find({});
-  } else if (type === "staff") {
-    list = await staffModel.find({});
-  } else if (type === "year") {
-    list = await yearModel.find({});
-  }
+export async function createRoles<T extends IRole>(
+  guild: Guild,
+  model: Model<T>
+): Promise<void> {
+  let list = await model.find({});
 
   list?.forEach(async (element) => {
     if (!guild.roles.cache.find((r) => r.name === element.ROLE_NAME)) {

--- a/rolesOps.ts
+++ b/rolesOps.ts
@@ -133,7 +133,7 @@ export async function checkForRoles(guild: Guild): Promise<boolean> {
       if (name == undefined && id == undefined) {
         console.log(
           chalk.red.bold(
-            `Role ${name} does not exist in ${guild.name}, Please run the /createRoles command in that server.`
+            `Role ${element.ROLE_NAME} does not exist in ${guild.name}, Please run the /createRoles command in that server.`
           )
         );
         collection.push(false);

--- a/rolesOps.ts
+++ b/rolesOps.ts
@@ -1,8 +1,8 @@
 import { GuildMember, Guild } from "discord.js";
 import chalk from "chalk";
-import classModel from "./models/classModel";
-import staffModel from "./models/staffModel";
-import yearModel from "./models/yearModel";
+import { classModel } from "./models/classModel";
+import { staffModel } from "./models/staffModel";
+import { yearModel } from "./models/yearModel";
 
 async function dbQuery() {
   const classes = await classModel.find({});

--- a/rolesOps.ts
+++ b/rolesOps.ts
@@ -34,20 +34,13 @@ export async function getUsersRoles(member: GuildMember): Promise<string> {
   return list;
 }
 
-export async function removeRole(
+export async function removeRole<T extends IRole>(
   member: GuildMember,
-  type: string
+  model: Model<T>
 ): Promise<void> {
   // This function is triggered when a user changes their role,
   // it removes the previous role from the user
-  let list: any[] = [];
-  if (type === "class") {
-    list = await classModel.find({});
-  } else if (type === "staff") {
-    list = await staffModel.find({});
-  } else if (type === "year") {
-    list = await yearModel.find({});
-  }
+  const list = await model.find({});
 
   for (const role of list) {
     if (member.roles.cache.has(role.ROLE_ID)) {

--- a/rolesOps.ts
+++ b/rolesOps.ts
@@ -1,8 +1,8 @@
 import { GuildMember, Guild } from "discord.js";
 import chalk from "chalk";
-import { classModel, IClass } from "./models/classModel";
-import { staffModel, IStaff } from "./models/staffModel";
-import { yearModel, IYear } from "./models/yearModel";
+import { classModel } from "./models/classModel";
+import { staffModel } from "./models/staffModel";
+import { yearModel } from "./models/yearModel";
 import { Model } from "mongoose";
 
 export interface IRole {
@@ -91,7 +91,7 @@ export async function createRoles<T extends IRole>(
   guild: Guild,
   model: Model<T>
 ): Promise<void> {
-  let list = await model.find({});
+  const list = await model.find({});
 
   list?.forEach(async (element) => {
     if (!guild.roles.cache.find((r) => r.name === element.ROLE_NAME)) {


### PR DESCRIPTION
## Add interfaces for models to add strong typing when passing them to functions

## Pass models rather than strings into role functions
- Add interfaces for models and a role interface
- Rewrite Role commands to be generic across role interfaces
- Fixed typing issues in rolesOps once strong typing was implemented for models
- Rename schemas to align with mongoose's naming conventions

## Bugfixes
- Correctly print the name of role if it is missing from a server
- Add missing awaits to async functions
- Revert chalk version from 5 to 4


## Misc
- Add check to confirm collections exist on bot boot
- Add all env files gitignore to help with multiple servers



