### PR TITLE
Bugfix/nathen418/update docker publish

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -13,7 +13,7 @@ jobs:
      #This Action Emits 2 Variables, IMAGE_SHA_NAME and IMAGE_URL 
      #which you can reference in subsequent steps
     - name: Publish Docker Image to GPR
-      uses: machine-learning-apps/gpr-docker-publish@main
+      uses: machine-learning-apps/gpr-docker-publish@master
       id: docker
       with:
         IMAGE_NAME: 'cssc-bot'


### PR DESCRIPTION
Signed-off-by: Nate Goldsborough <nathen418@playantares.com>

# Descriptive title

Updates the docker image publish workflow not to have a typo that causes it to fail

# Changes
- changes the `main` tag to `master`.   
`machine-learning-apps/gpr-docker-publish@main` --> `machine-learning-apps/gpr-docker-publish@master`