### PR TITLE
Replace string concatenation with template

### DIFF
--- a/commands/user/view.ts
+++ b/commands/user/view.ts
@@ -25,7 +25,7 @@ export default {
       });
     } else {
       interaction.reply({
-        content: "**Your roles:**\n" + list,
+        content: `**Your roles:**\n${list}`,
         ephemeral: true,
       });
     }


### PR DESCRIPTION
# Swap from string concatenation to template

Fixes deepsource error in PR #44 
String literals are generally considered better than concatenation. 

# Link to github card
#44 

# Changes 

*  Replace string concatenation with template
