### PR TITLE
Prevent error when statuspage env vars are not set

### DIFF
--- a/features/statuspage.ts
+++ b/features/statuspage.ts
@@ -5,7 +5,11 @@ import { isDocker } from "../utils/docker";
 export default (client: Client): void => {
   // Check if the bot is running in a docker container by checking if the env variable UPTIME_KUMA_CONTAINERIZED is true
   if (isDocker()) return;
-  if (!process.env.UPTIME_KUMA_MONITOR_DOMAIN || !process.env.UPTIME_KUMA_MONITOR_ID) return;
+  if (
+    !process.env.UPTIME_KUMA_MONITOR_DOMAIN ||
+    !process.env.UPTIME_KUMA_MONITOR_ID
+  )
+    return;
   const updateStatus = async () => {
     // This function is called every 1 minutes and pings the network status page for uptime monitoring
     await axios.get(

--- a/features/statuspage.ts
+++ b/features/statuspage.ts
@@ -5,6 +5,7 @@ import { isDocker } from "../utils/docker";
 export default (client: Client): void => {
   // Check if the bot is running in a docker container by checking if the env variable UPTIME_KUMA_CONTAINERIZED is true
   if (isDocker()) return;
+  if (!process.env.UPTIME_KUMA_MONITOR_DOMAIN || !process.env.UPTIME_KUMA_MONITOR_ID) return;
   const updateStatus = async () => {
     // This function is called every 1 minutes and pings the network status page for uptime monitoring
     await axios.get(


### PR DESCRIPTION
# Remove need for statuspage env vars

Fixes an issue where if you try to run the bot without statuspage variables set and the bot is not in a docker container, it will throw an error


# Changes
- simply return if either of the statuspage env vars are not set.
