### PR TITLE
Bugfix/schiltz3/deepsource2

### DIFF
--- a/commands/owner/csCreateChannels.ts
+++ b/commands/owner/csCreateChannels.ts
@@ -93,9 +93,9 @@ export default {
       const children = Array.from(cs_category.children.values());
       for (let index = 0; index < children.length; index++) {
         const match = cleaned_courses.find((course) => {
-          return course == children[index].name;
+          return course === children[index].name;
         });
-        if (match != undefined) {
+        if (match !== undefined) {
           continue;
         }
         console.log(`Moving: ${children[index]} to: ${cs_past_category_name}`);
@@ -165,7 +165,7 @@ export default {
         // Ping members who have this role
         const found_role = msgInt.guild.roles.cache.find((role) => {
           return (
-            cleanRoleString(role.name) ==
+            cleanRoleString(role.name) ===
             cleanChannelString(courses[index].CODE)
           );
         });
@@ -198,7 +198,7 @@ export default {
         // Ping members who have this role
         const found_role = msgInt.guild.roles.cache.find((role) => {
           return (
-            cleanRoleString(role.name) ==
+            cleanRoleString(role.name) ===
             cleanChannelString(courses[index].CODE)
           );
         });

--- a/index.ts
+++ b/index.ts
@@ -37,8 +37,9 @@ client.on("ready", async () => {
     console.log("Checking if all roles exist in servers.");
 
     await Promise.all(
+      // skipcq JS-0042
       client.guilds.cache.map((guild) => {
-        checkForRoles(guild); // skipcq JS-0042
+        checkForRoles(guild);
       })
     );
   }

--- a/utils/channels.ts
+++ b/utils/channels.ts
@@ -11,7 +11,7 @@ export function cleanChannelString(s: string): string {
 
 export function checkForChannel(guild: Guild, channel_name: string) {
   return guild.channels.cache.find((channel) => {
-    return channel.name == channel_name;
+    return channel.name === channel_name;
   });
 }
 


### PR DESCRIPTION
# Deepsource fixes 2

Fix several more instances of using `==` rather than `===`
moves the ignored comment to the (hopefully) correct line.

# Changes
* Replace `==` with `===`
* put ignore comment on the correct line
* rename lambda variables to not shadow function variables